### PR TITLE
DOS: fix int08 stack for DPMI mode.

### DIFF
--- a/iss_tim.pas
+++ b/iss_tim.pas
@@ -61,6 +61,8 @@ Function ISS_GetTimerNumber(TimerProc : Pointer) : DWord;
 
 Implementation
 
+Var IntStack        : array[0..4095] of byte;
+
 Var TimerSpeed      : DWord;
     OldTimer        : TSegInfo;
     OldTimerCnt     : DWord;
@@ -96,7 +98,16 @@ Asm
   PUSH   FS
   PUSH   GS
   PUSHAD
+
+  { with DPMI, the stack is not DS/ES, but a minimal 4K locked pm stack dedicated for interrupts, switch to DS }
+  MOV    CX, SS
+  MOV    EDX, ESP
   MOV    AX,CS:[BackupDS]
+  MOV    SS, AX
+  LEA    ESP, IntStack+4096
+  PUSH   CX
+  PUSH   EDX
+
   MOV    DS,AX
   MOV    ES,AX
   MOV    AX,DosMemSelector
@@ -129,6 +140,13 @@ Asm
   MOV   DX,$20 { þ Interrupt request acknowledge þ }
   MOV   AL,$20
   OUT   DX,AL
+
+  {restore old stack}
+  POP   EDX
+  POP   CX
+  MOV   SS, CX
+  MOV   ESP, EDX
+
   POPAD
   POP   GS
   POP   FS


### PR DESCRIPTION
The DPMI spec requires a DPMI host to provide a locked protected mode stack for hardware interrupts. So after the interrupt handler changing DS/ES, DS equals ES, but SS is not. but the compiled code assume SS also equals DS (flat/small model). The crashed disassembly for timer_poll_proc_ptr looks like this:

```
mov edi, ebp
...
stosb 
```
Here EBP by default is using SS, but stos uses ES, thus cause a incorrect address.

This problem does not exist when no DPMI present, as the GO32v2 extender will provide a interrupt stack that uses program current DS. But it won't work with CWSDPMI.

After the fix, it should work with CWSDPMI and probably Windows too. And works with SBEMU. FYI SBEMU provides OPL3 emulation using modern sound cards (AC97, Intel HDA etc.).